### PR TITLE
Update to Elixir 1.3/Erlang 18.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,36 +4,28 @@ MAINTAINER Adam Radabaugh <adam@walkingtoast.com>
 
 # Elixir requires UTF-8
 RUN locale-gen en_US.UTF-8
+
+ENV ELIXIR_VERSION 1.3.0
+ENV ERLANG_VERSION 18.3
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+ENV PHOENIX_VERSION 1.1.6
 
 # update and install some software requirements
 RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y curl wget git make mysql-client postgresql-client --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# download and install Erlang package
+# Install Elixir using recommended steps from http://elixir-lang.org/install.html#unix-and-unix-like
 RUN wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
  && dpkg -i erlang-solutions_1.0_all.deb \
- && apt-get update
+ && rm erlang-solutions_1.0_all.deb \
+ && apt-get update \
+ && apt-get install -y esl-erlang=1:$ERLANG_VERSION elixir=$ELIXIR_VERSION-1
 
-# install erlang from package
-RUN apt-get install -y erlang erlang-ssl erlang-inets && rm erlang-solutions_1.0_all.deb
-
-ENV ELIXIR_VERSION 1.2.6
-
-# install elixir from source
-RUN git clone https://github.com/elixir-lang/elixir.git && cd elixir && git checkout v$ELIXIR_VERSION && make
-ENV PATH $PATH:/elixir/bin
-
-ENV PHOENIX_VERSION 1.1.6
-
-# install Phoenix from source with some previous requirements
-RUN git clone https://github.com/phoenixframework/phoenix.git \
- && cd phoenix && git checkout v$PHOENIX_VERSION \
- && mix local.hex --force && mix local.rebar --force \
- && mix do deps.get, compile \
- && mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new-$PHOENIX_VERSION.ez
+RUN mix local.hex --force
+RUN mix local.rebar --force
+RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new-$PHOENIX_VERSION.ez
 
 WORKDIR /code


### PR DESCRIPTION
# Changelog
## Enhancements
- Update to Elixir 1.3/Erlang 18.3 using the recommended installation process for Elixir and Phoenix from their respective installation guides.
